### PR TITLE
fix new haproxy api return 404 instead of 204 on read maps_entries

### DIFF
--- a/internal/haproxy/haproxy.go
+++ b/internal/haproxy/haproxy.go
@@ -15,6 +15,8 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+var ErrNotFound = errors.New("NotFound")
+
 func NewClient(username string, password string, server_url string, insecure bool) *Client {
 	scheme := "https"
 	if insecure {
@@ -45,6 +47,11 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		// Latest version of haproxy API return 404 now instead of 204 before.
+		return ErrNotFound
+	}
 
 	// Try to unmarshall into errorResponse
 	if res.StatusCode >= 300 {

--- a/internal/provider/resource_maps.go
+++ b/internal/provider/resource_maps.go
@@ -112,9 +112,16 @@ func resourceMapsRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	client := meta.(*haproxy.Client)
 
 	mapEntrie, err := client.GetMapEntrie(d.Id(), d.Get("map").(string))
-	if err != nil {
-		diag.FromErr(err)
+
+	if errors.Is(err, haproxy.ErrNotFound) {
+		d.SetId("")
+		return nil
 	}
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.Set("key", mapEntrie.Key)
 	d.Set("value", mapEntrie.Value)
 	d.Set("map", d.Get("map").(string))
@@ -129,7 +136,7 @@ func resourceMapsUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		mapName := d.Get("map").(string)
 		entrie, err := client.GetMapEntrie(d.Get("key").(string), mapName)
 		if err != nil {
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		entrie.Value = d.Get("value").(string)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxytech/haproxy-alpine:2.4
+FROM haproxytech/haproxy-alpine:2.6.5
 
 COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 


### PR DESCRIPTION
After upgrading haproxy to latest version : 2.6.5. Terraform provider cannot reads anymore maps_entries.

Haproxy api was returning 404 on object that do not exist anymore but are still in tfstate. Before it was returning 204 status code that was already manage by  this provider. On 404 error , adding SetId("") perform a clean in tfstate for ressources that do not exist anymore in haproxy.

Thanks @golgoth31 for the participation to the issue.